### PR TITLE
ADD CMAKE BUILD FILES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,97 @@
+# Written in 2015 by Henrik Steffen Gaﬂmann henrik@gassmann.onl
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+#
+#     http://creativecommons.org/publicdomain/zero/1.0/
+#
+########################################################################
+cmake_minimum_required(VERSION 3.0)
+cmake_policy(VERSION 3.0)
+cmake_policy(SET CMP0054 NEW)
+project(libb2 VERSION 0.97)
+
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+	message(FATAL_ERROR "in-source builds are not supported!")
+endif()
+
+# add cmake script path
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
+# set pre install output directories
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+if(MSVC)
+    set(CMAKE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+endif()
+
+########################################################################
+# platform detection/compiler support
+include(TestBigEndian)
+TEST_BIG_ENDIAN(BLAKE2_BIG_ENDIAN)
+
+# SSE feature level
+include(CheckSSESupport)
+set(BLAKE2_SSE_LEVELS NO_SSE) #0
+if(SSE2_AVAILABLE)
+    list(APPEND BLAKE2_SSE_LEVELS SSE2) #1
+    if(SSSE3_AVAILABLE)
+        list(APPEND BLAKE2_SSE_LEVELS SSSE3) #2
+        if(SSE41_AVAILABLE)
+            list(APPEND BLAKE2_SSE_LEVELS SSE4_1) #3
+            if (AVX_AVAILABLE)
+                list(APPEND BLAKE2_SSE_LEVELS AVX) #4
+                if (XOP_AVAILABLE)
+                    list(APPEND BLAKE2_SSE_LEVELS XOP) #5
+                endif()
+            endif()
+        endif()
+    endif()
+endif()
+
+if (XOP_AVAILABLE)
+    option(BLAKE2_FAT_BINARIES "build fat binaries with all available SSE code paths." ON)
+endif()
+if (BLAKE2_FAT_BINARIES)
+    list(FIND BLAKE2_SSE_LEVELS XOP BLAKE2_EIS_IDX)
+else()
+    list(FIND BLAKE2_SSE_LEVELS NO_SSE BLAKE2_EIS_IDX)
+endif()
+
+# openmp support
+include(CheckOpenMPSupport)
+if(OpenMP_AVAILABLE)
+    option(BLAKE2_UTILIZE_OPENMP "" ON)
+else()
+    set(BLAKE2_UTILIZE_OPENMP OFF)
+endif()
+
+option(BLAKE2_BUILD_TESTS "")
+option(BLAKE2_SHARED_OBJECT "build a dynamic link library instead of a static one")
+
+########################################################################
+# add project
+add_subdirectory(src)
+
+########################################################################
+# install target
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/libb2-config-version.cmake"
+  VERSION ${libb2_VERSION}
+  COMPATIBILITY ExactVersion
+)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libb2-config-version.cmake" DESTINATION cmake)
+
+configure_file(cmake/libb2-config.cmake
+  "${CMAKE_CURRENT_BINARY_DIR}/libb2-config.cmake"
+  COPYONLY
+)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libb2-config.cmake" DESTINATION cmake)
+
+install(EXPORT libb2-targets DESTINATION cmake)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 C library providing BLAKE2b, BLAKE2s, BLAKE2bp, BLAKE2sp
 
-Installation:
+## Installation
 
+### Autotools
 ```
 $ ./autogen.sh
 $ ./configure
@@ -11,4 +12,11 @@ $ make
 $ sudo make install
 ```
 
-Contact: contact@blake2.net
+### CMake
+On Windows CMake can generate make/project files for Visual Studio, MinGW and Clang.
+The install target will create and install a proper package config. The import project is called `libb2`.
+
+Please note that the CMake project is incapable of configuring OpenMP support on Clang.
+
+## Contact
+[contact@blake2.net](mailto:contact@blake2.net)

--- a/cmake/CheckOpenMPSupport.cmake
+++ b/cmake/CheckOpenMPSupport.cmake
@@ -1,0 +1,39 @@
+# Written in 2015 by Henrik Steffen Gaﬂmann henrik@gassmann.onl
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+#
+#     http://creativecommons.org/publicdomain/zero/1.0/
+#
+########################################################################
+
+include(CheckCSourceCompiles)
+
+set(O_FLAGS ${CMAKE_REQUIRED_FLAGS})
+set(O_DEFS ${CMAKE_REQUIRED_DEFINITIONS})
+
+if(MSVC)
+    set(CMAKE_REQUIRED_FLAGS "${O_FLAGS} /openmp")
+elseif(CMAKE_COMPILER_IS_GNUCC)
+    set(CMAKE_REQUIRED_FLAGS "${O_FLAGS} -fopenmp")
+elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+    # don't know how to enable clang's openmp support
+endif()
+check_c_source_compiles("
+    #include <omp.h>
+    #ifndef _OPENMP
+    #error \"_OPENMP not defined\"
+    #endif
+    int main()
+    {
+        char hash[1024];
+        omp_set_num_threads(4);
+        #pragma omp parallel shared(hash)
+        omp_get_thread_num();
+        return 0;
+    }
+" OpenMP_AVAILABLE)

--- a/cmake/CheckSSESupport.cmake
+++ b/cmake/CheckSSESupport.cmake
@@ -1,0 +1,180 @@
+# Written in 2015 by Henrik Steffen Gaﬂmann henrik@gassmann.onl
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+#
+#     http://creativecommons.org/publicdomain/zero/1.0/
+#
+########################################################################
+
+include(CheckCSourceCompiles)
+
+set(O_FLAGS ${CMAKE_REQUIRED_FLAGS})
+set(O_DEFS ${CMAKE_REQUIRED_DEFINITIONS})
+
+set(SSE2_CODE "
+    #ifdef _MSC_VER
+    #include <intrin.h>
+    #endif
+    #include <emmintrin.h>
+    
+    int main()
+    {
+        __m128i m128i;
+        /* common intrinsics */
+        _mm_loadu_si128(&m128i);
+        _mm_storeu_si128(&m128i, m128i);
+        _MM_SHUFFLE(0,3,2,1);
+        
+        /* blake2s intrinsics */
+        _mm_set_epi32(0,0,0,0);
+        _mm_xor_si128(m128i,m128i);
+        _mm_srli_epi32(m128i,0);
+        _mm_slli_epi32(m128i,0);
+        _mm_add_epi32(m128i,m128i);
+        _mm_shuffle_epi32(m128i,0);
+        _mm_setr_epi32(0,0,0,0);
+        
+        /* blake2b intrinsics */
+        
+        
+        return 0;
+    }
+")
+set(SSSE3_CODE "
+    #ifdef _MSC_VER
+    #include <intrin.h>
+    #endif
+    #include <emmintrin.h>
+    #include <tmmintrin.h>
+    
+    int main()
+    {
+        __m128 m128;
+        __m128i m128i;
+        /* common intrinsics */
+        _mm_castsi128_ps(m128i);
+        _mm_castps_si128(m128);
+        
+        /* blake2s intrinsics */
+        _mm_shuffle_epi8(m128i,m128i);
+        
+        /* blake2b intrinsics */
+        
+        
+        return 0;
+    }
+")
+set(SSE41_CODE "
+    #ifdef _MSC_VER
+    #include <intrin.h>
+    #endif
+    #include <emmintrin.h>
+    #include <tmmintrin.h>
+    #include <smmintrin.h>
+    
+    int main()
+    {
+        __m128 m128;
+        __m128i m128i;
+        /* blake2s intrinsics */
+        _mm_shuffle_ps(m128, m128, 0);
+        _mm_blend_epi16(m128i, m128i, 0);
+        _mm_slli_si128(m128i, 0); /*SSE2*/
+        _mm_srli_si128(m128i, 0); /*SSE2*/
+        _mm_shufflehi_epi16(m128i, 0); /*SSE2*/
+        _mm_unpacklo_epi32(m128i, m128i); /*SSE2*/
+        _mm_unpacklo_epi64(m128i, m128i); /*SSE2*/
+        _mm_unpackhi_epi32(m128i, m128i); /*SSE2*/
+        _mm_unpackhi_epi64(m128i, m128i); /*SSE2*/
+        
+        /* blake2b intrinsics */
+        
+        
+        return 0;
+    }
+")
+# correct this if i'm wrong, but I couldn't find any AVX intrinsics :(
+#set(AVX_CODE "
+#    #ifdef _MSC_VER
+#    #include <intrin.h>
+#    #endif
+#    #include <emmintrin.h>
+#    #include <tmmintrin.h>
+#    #include <smmintrin.h>
+#    #include <immintrin.h>
+#    
+#    int main()
+#    {
+#        __m128i m128;
+#        //blake2s intrinsics
+#        
+#        //blake2b intrinsics
+#        
+#        
+#        return 0;
+#    }
+#")
+set(XOP_CODE "
+    #ifdef _MSC_VER
+    #include <intrin.h>
+    #include <ammintrin.h>
+    #else
+    #include <x86intrin.h>
+    #endif
+    #include <emmintrin.h>
+    #include <tmmintrin.h>
+    #include <smmintrin.h>
+    #include <immintrin.h>
+    
+    int main()
+    {
+        __m128i m128i;
+        /* blake2s intrinsics */
+        _mm_roti_epi32(m128i,0);
+        _mm_perm_epi8(m128i,m128i,m128i);
+        
+        /* blake2b intrinsics */
+        
+        
+        return 0;
+    }
+")
+
+if(CMAKE_COMPILER_IS_GNUCC OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang"))
+    set(CMAKE_REQUIRED_FLAGS "${O_FLAGS} -msse2")
+endif()
+check_c_source_compiles("${SSE2_CODE}" SSE2_AVAILABLE)
+
+if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+    set(CMAKE_REQUIRED_FLAGS "${O_FLAGS} -msse2 -mssse3")
+endif()
+check_c_source_compiles("${SSSE3_CODE}" SSSE3_AVAILABLE)
+
+if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+    set(CMAKE_REQUIRED_FLAGS "${O_FLAGS} -msse2 -mssse3 -msse4.1")
+endif()
+check_c_source_compiles("${SSE41_CODE}" SSE41_AVAILABLE)
+
+#if(CMAKE_COMPILER_IS_GNUCC)
+#    set(CMAKE_REQUIRED_FLAGS "${O_FLAGS} -msse2 -mssse3 -msse4.1 -mavx")
+#endif()
+#check_c_source_compiles("${AVX_CODE}" AVX_AVAILABLE)
+set(AVX_AVAILABLE 1)
+
+if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+    set(CMAKE_REQUIRED_FLAGS "${O_FLAGS} -msse2 -mssse3 -msse4.1 -mxop")
+endif()
+check_c_source_compiles("${XOP_CODE}" XOP_AVAILABLE)
+
+unset(XOP_CODE)
+#unset(AVX_CODE)
+unset(SSE41_CODE)
+unset(SSSE3_CODE)
+unset(SSE2_CODE)
+unset(O_DEFS)
+unset(O_FLAGS)

--- a/cmake/libb2-config.cmake
+++ b/cmake/libb2-config.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/libb2-targets.cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,185 @@
+# Written in 2015 by Henrik Steffen Gaﬂmann henrik@gassmann.onl
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+#
+#     http://creativecommons.org/publicdomain/zero/1.0/
+#
+########################################################################
+
+if(BLAKE2_SHARED_OBJECT)
+    set(BLAKE2_SHARED_LIBRARY_VAL 1)
+    set(BLAKE2_SHARED_LIBRARY_DEF SHARED)
+else()
+    set(BLAKE2_SHARED_LIBRARY_VAL 0)
+    set(BLAKE2_SHARED_LIBRARY_DEF STATIC)
+endif()
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(LIBB2_SUFFIX_LIST _sse2 _ssse3 _sse41 _avx _xop)
+
+set(COUNTER 0)
+while(COUNTER LESS BLAKE2_EIS_IDX)
+    list(GET LIBB2_SUFFIX_LIST ${COUNTER} _CURR_SUFFIX) 
+    MATH(EXPR COUNTER "0${COUNTER}+1")
+    
+    list(GET BLAKE2_SSE_LEVELS ${COUNTER} _CURR_LEVEL)
+    #list(APPEND BLAKE2_IMPL_LIST ${_CURR_LEVEL})
+    
+    set(_CURR_B2S_FILE "${CMAKE_CURRENT_BINARY_DIR}/blake2s_${_CURR_LEVEL}.c")
+    set(_CURR_B2B_FILE "${CMAKE_CURRENT_BINARY_DIR}/blake2b_${_CURR_LEVEL}.c")
+    configure_file("blake2s.c"
+        ${_CURR_B2S_FILE}
+        COPYONLY
+    )
+    configure_file("blake2b.c"
+        ${_CURR_B2B_FILE}
+        COPYONLY
+    )
+    set(_CURR_FILES ${_CURR_B2S_FILE} ${_CURR_B2B_FILE})
+    list(APPEND BLAKE2_IMPL_SOURCES ${_CURR_FILES})
+    
+    if(COUNTER GREATER 0)
+        list(APPEND FEATURE_DEFS HAVE_${_CURR_LEVEL})
+        if (CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+            if(COUNTER GREATER 4)
+                set(FEATURE_FLAGS "${FEATURE_FLAGS} -mxop")
+            elseif(COUNTER GREATER 3)
+                set(FEATURE_FLAGS "${FEATURE_FLAGS} -mavx")
+            elseif(COUNTER GREATER 2)
+                set(FEATURE_FLAGS "${FEATURE_FLAGS} -msse4.1")
+            elseif(COUNTER GREATER 1)
+                set(FEATURE_FLAGS "${FEATURE_FLAGS} -mssse3")
+            else()
+                set(FEATURE_FLAGS -msse2)
+            endif()
+        endif()
+    endif()
+    
+    set_source_files_properties(${_CURR_FILES} PROPERTIES
+        COMPILE_FLAGS "${FEATURE_FLAGS}"
+        COMPILE_DEFINITIONS "SUFFIX=${_CURR_SUFFIX};${FEATURE_DEFS}"
+    )
+    
+    unset(_CURR_FILES)
+    unset(_CURR_B2B_FILE)
+    unset(_CURR_B2S_FILE)
+    unset(_CURR_SUFFIX)
+    unset(_CURR_LEVEL)
+endwhile()
+unset(FEATURE_FLAGS)
+unset(FEATURE_DEFS)
+unset(COUNTER)
+
+if(NOT (BLAKE2_EIS_IDX EQUAL 0))
+    set_source_files_properties(blake2b-ref.c blake2s-ref.c PROPERTIES
+        COMPILE_DEFINITIONS "SUFFIX=_ref"
+    )
+else()
+    set_source_files_properties(blake2b-ref.c blake2s-ref.c PROPERTIES
+        COMPILE_DEFINITIONS "SUFFIX="
+    )
+endif()
+
+add_library(libb2 ${BLAKE2_SHARED_LIBRARY_DEF}
+    blake2.h
+    blake2-config.h
+    blake2-impl.h
+    $<$<NOT:$<EQUAL:${BLAKE2_EIS_IDX},0>>:blake2-dispatch.c>
+    
+    
+    blake2b-ref.c
+    blake2b-round.h
+    blake2b-load-sse2.h
+    blake2b-load-sse41.h
+    
+    blake2bp.c
+    
+    
+    blake2s-ref.c
+    blake2s-round.h
+    blake2s-load-sse2.h
+    blake2s-load-sse41.h
+    blake2s-load-xop.h
+    
+    blake2sp.c
+    
+    ${BLAKE2_IMPL_SOURCES}
+)
+
+source_group(common REGULAR_EXPRESSION .*blake2.*)
+source_group(blake2s REGULAR_EXPRESSION .*blake2s.*)
+source_group(blake2b REGULAR_EXPRESSION .*blake2b.*)
+
+########################################################################
+# config
+target_compile_definitions(libb2
+    PRIVATE
+        _UNICODE
+        NO_CONFIG
+        $<$<NOT:$<BOOL:${BLAKE2_BIG_ENDIAN}>>:NATIVE_LITTLE_ENDIAN>
+        $<${BLAKE2_SHARED_LIBRARY_VAL}:BLAKE2_DLL_EXPORTS>
+        
+    PUBLIC
+        $<${BLAKE2_SHARED_LIBRARY_VAL}:BLAKE2_DLL>
+)
+set_target_properties(libb2 PROPERTIES PREFIX "")
+
+if(BLAKE2_UTILIZE_OPENMP)
+    if(MSVC)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /openmp")
+    elseif(CMAKE_COMPILER_IS_GNUCC)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fopenmp")
+    endif()
+endif()
+
+########################################################################
+# install target
+install(TARGETS libb2 EXPORT libb2-targets
+    RUNTIME DESTINATION bin/$<CONFIG>
+    LIBRARY DESTINATION lib/$<CONFIG>
+    ARCHIVE DESTINATION lib/$<CONFIG>
+    INCLUDES DESTINATION include
+)
+install(FILES blake2.h DESTINATION include)
+
+
+########################################################################
+# test drivers
+
+if(BLAKE2_BUILD_TESTS)
+
+    # BLAKE2 B
+    add_executable(blake2b_test
+        blake2b-test.c
+        blake2-kat.h
+    )
+    target_link_libraries(blake2b_test PRIVATE libb2)
+
+    # BLAKE2 S
+    add_executable(blake2s_test
+        blake2s-test.c
+        blake2-kat.h
+    )
+    target_link_libraries(blake2s_test PRIVATE libb2)
+
+    # BLAKE2 BP
+    add_executable(blake2bp_test
+        blake2bp-test.c
+        blake2-kat.h
+    )
+    target_link_libraries(blake2bp_test PRIVATE libb2)
+
+    # BLAKE2 SP
+    add_executable(blake2sp_test
+        blake2sp-test.c
+        blake2-kat.h
+    )
+    target_link_libraries(blake2sp_test PRIVATE libb2)
+
+endif()

--- a/src/blake2-impl.h
+++ b/src/blake2-impl.h
@@ -17,7 +17,9 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#ifndef NO_CONFIG
 #include "config.h"
+#endif
 
 #define BLAKE2_IMPL_CAT(x,y) x ## y
 #define BLAKE2_IMPL_EVAL(x,y)  BLAKE2_IMPL_CAT(x,y)


### PR DESCRIPTION
I ported my CMake build scripts from [BurningEnlightenment/libb2-cmake](https://github.com/BurningEnlightenment/libb2-cmake).

It supports building the library with all code paths or with reference sources only with MSVC, MinGW and Clang (tested only on Windows), although it currently lacks OpenMP support on Clang. Furthermore it can build the test drivers.

However, the main feature is the install target which allows the library to be used from other CMake projects (especially on Windows) very easily.