### PR TITLE
Fix implicit conversions and enable warnings

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,7 +19,8 @@ lib_LTLIBRARIES = libb2.la
 libb2_la_LIBADD = # -lgomp -lpthread
 libb2_la_CPPFLAGS =  -DSUFFIX=  \
                      $(LTDLINCL) \
-                     ${top_builddir}/src/
+                     ${top_builddir}/src/ \
+                     -Wconversion
 
 include_HEADERS = blake2.h
 

--- a/src/blake2b.c
+++ b/src/blake2b.c
@@ -235,7 +235,7 @@ int blake2b_init( blake2b_state *S, size_t outlen )
 
   const blake2b_param P =
   {
-    outlen,
+    ( uint8_t ) outlen,
     0,
     1,
     1,
@@ -258,8 +258,8 @@ int blake2b_init_key( blake2b_state *S, size_t outlen, const void *key, size_t k
 
   const blake2b_param P =
   {
-    outlen,
-    keylen,
+    ( uint8_t ) outlen,
+    ( uint8_t ) keylen,
     1,
     1,
     0,
@@ -359,8 +359,8 @@ int blake2b_update( blake2b_state *S, const uint8_t *in, size_t inlen )
 {
   while( inlen > 0 )
   {
-    size_t left = S->buflen;
-    size_t fill = 2 * BLAKE2B_BLOCKBYTES - left;
+    uint32_t left = S->buflen;
+    uint32_t fill = 2 * BLAKE2B_BLOCKBYTES - left;
 
     if( inlen > fill )
     {
@@ -376,7 +376,7 @@ int blake2b_update( blake2b_state *S, const uint8_t *in, size_t inlen )
     else // inlen <= fill
     {
       memcpy( S->buf + left, in, inlen );
-      S->buflen += inlen; // Be lazy, do not compress
+      S->buflen += ( uint32_t ) inlen; // Be lazy, do not compress
       in += inlen;
       inlen -= inlen;
     }

--- a/src/blake2bp.c
+++ b/src/blake2bp.c
@@ -71,15 +71,15 @@ int blake2bp_init( blake2bp_state *S, size_t outlen )
   memset( S->buf, 0, sizeof( S->buf ) );
   S->buflen = 0;
 
-  if( blake2bp_init_root( S->R, outlen, 0 ) < 0 )
+  if( blake2bp_init_root( S->R, ( uint8_t ) outlen, 0 ) < 0 )
     return -1;
 
   for( size_t i = 0; i < PARALLELISM_DEGREE; ++i )
-    if( blake2bp_init_leaf( S->S[i], outlen, 0, i ) < 0 ) return -1;
+    if( blake2bp_init_leaf( S->S[i], ( uint8_t ) outlen, 0, i ) < 0 ) return -1;
 
   S->R->last_node = 1;
   S->S[PARALLELISM_DEGREE - 1]->last_node = 1;
-  S->outlen = outlen;
+  S->outlen = ( uint8_t ) outlen;
   return 0;
 }
 
@@ -92,15 +92,16 @@ int blake2bp_init_key( blake2bp_state *S, size_t outlen, const void *key, size_t
   memset( S->buf, 0, sizeof( S->buf ) );
   S->buflen = 0;
 
-  if( blake2bp_init_root( S->R, outlen, keylen ) < 0 )
+  if( blake2bp_init_root( S->R, ( uint8_t ) outlen, ( uint8_t ) keylen ) < 0 )
     return -1;
 
   for( size_t i = 0; i < PARALLELISM_DEGREE; ++i )
-    if( blake2bp_init_leaf( S->S[i], outlen, keylen, i ) < 0 ) return -1;
+    if( blake2bp_init_leaf( S->S[i], ( uint8_t ) outlen, ( uint8_t ) keylen, i ) < 0 )
+      return -1;
 
   S->R->last_node = 1;
   S->S[PARALLELISM_DEGREE - 1]->last_node = 1;
-  S->outlen = outlen;
+  S->outlen = ( uint8_t ) outlen;
   {
     uint8_t block[BLAKE2B_BLOCKBYTES];
     memset( block, 0, BLAKE2B_BLOCKBYTES );
@@ -140,7 +141,7 @@ int blake2bp_update( blake2bp_state *S, const uint8_t *in, size_t inlen )
 #endif
   {
 #if defined(_OPENMP)
-    size_t      id__ = omp_get_thread_num();
+    size_t      id__ = ( size_t ) omp_get_thread_num();
 #endif
     size_t inlen__ = inlen;
     const uint8_t *in__ = ( const uint8_t * )in;
@@ -160,7 +161,7 @@ int blake2bp_update( blake2bp_state *S, const uint8_t *in, size_t inlen )
   if( inlen > 0 )
     memcpy( S->buf + left, in, inlen );
 
-  S->buflen = left + inlen;
+  S->buflen = ( uint32_t ) left + ( uint32_t ) inlen;
   return 0;
 }
 
@@ -210,7 +211,8 @@ int blake2bp( uint8_t *out, const void *in, const void *key, size_t outlen, size
   if( keylen > BLAKE2B_KEYBYTES ) return -1;
 
   for( size_t i = 0; i < PARALLELISM_DEGREE; ++i )
-    if( blake2bp_init_leaf( S[i], outlen, keylen, i ) < 0 ) return -1;
+    if( blake2bp_init_leaf( S[i], ( uint8_t ) outlen, ( uint8_t ) keylen, i ) < 0 )
+      return -1;
 
   S[PARALLELISM_DEGREE - 1]->last_node = 1; // mark last node
 
@@ -234,7 +236,7 @@ int blake2bp( uint8_t *out, const void *in, const void *key, size_t outlen, size
 #endif
   {
 #if defined(_OPENMP)
-    size_t      id__ = omp_get_thread_num();
+    size_t      id__ = ( size_t ) omp_get_thread_num();
 #endif
     size_t inlen__ = inlen;
     const uint8_t *in__ = ( const uint8_t * )in;
@@ -257,7 +259,7 @@ int blake2bp( uint8_t *out, const void *in, const void *key, size_t outlen, size
     blake2b_final( S[id__], hash[id__], BLAKE2B_OUTBYTES );
   }
 
-  if( blake2bp_init_root( FS, outlen, keylen ) < 0 )
+  if( blake2bp_init_root( FS, ( uint8_t ) outlen, ( uint8_t ) keylen ) < 0 )
     return -1;
 
   FS->last_node = 1; // Mark as last node

--- a/src/blake2s-ref.c
+++ b/src/blake2s-ref.c
@@ -181,7 +181,7 @@ int blake2s_init( blake2s_state *S, size_t outlen )
   /* Move interval verification here? */
   if ( ( !outlen ) || ( outlen > BLAKE2S_OUTBYTES ) ) return -1;
 
-  P->digest_length = outlen;
+  P->digest_length = ( uint8_t) outlen;
   P->key_length    = 0;
   P->fanout        = 1;
   P->depth         = 1;
@@ -203,8 +203,8 @@ int blake2s_init_key( blake2s_state *S, size_t outlen, const void *key, size_t k
 
   if ( !key || !keylen || keylen > BLAKE2S_KEYBYTES ) return -1;
 
-  P->digest_length = outlen;
-  P->key_length    = keylen;
+  P->digest_length = ( uint8_t ) outlen;
+  P->key_length    = ( uint8_t ) keylen;
   P->fanout        = 1;
   P->depth         = 1;
   store32( &P->leaf_length, 0 );
@@ -292,8 +292,8 @@ int blake2s_update( blake2s_state *S, const uint8_t *in, size_t inlen )
 {
   while( inlen > 0 )
   {
-    size_t left = S->buflen;
-    size_t fill = 2 * BLAKE2S_BLOCKBYTES - left;
+    uint32_t left = S->buflen;
+    uint32_t fill = 2 * BLAKE2S_BLOCKBYTES - left;
 
     if( inlen > fill )
     {
@@ -309,7 +309,7 @@ int blake2s_update( blake2s_state *S, const uint8_t *in, size_t inlen )
     else // inlen <= fill
     {
       memcpy( S->buf + left, in, inlen );
-      S->buflen += inlen; // Be lazy, do not compress
+      S->buflen += ( uint32_t ) inlen; // Be lazy, do not compress
       in += inlen;
       inlen -= inlen;
     }
@@ -321,6 +321,7 @@ int blake2s_update( blake2s_state *S, const uint8_t *in, size_t inlen )
 int blake2s_final( blake2s_state *S, uint8_t *out, size_t outlen )
 {
   uint8_t buffer[BLAKE2S_OUTBYTES];
+  size_t i;
 
   if(S->outlen != outlen) return -1;
 
@@ -337,7 +338,7 @@ int blake2s_final( blake2s_state *S, uint8_t *out, size_t outlen )
   memset( S->buf + S->buflen, 0, 2 * BLAKE2S_BLOCKBYTES - S->buflen ); /* Padding */
   blake2s_compress( S, S->buf );
 
-  for( int i = 0; i < 8; ++i ) /* Output full hash to temp buffer */
+  for( i = 0; i < 8; ++i ) /* Output full hash to temp buffer */
     store32( buffer + sizeof( S->h[i] ) * i, S->h[i] );
 
   memcpy( out, buffer, outlen );

--- a/src/blake2sp.c
+++ b/src/blake2sp.c
@@ -68,15 +68,15 @@ int blake2sp_init( blake2sp_state *S, size_t outlen )
   memset( S->buf, 0, sizeof( S->buf ) );
   S->buflen = 0;
 
-  if( blake2sp_init_root( S->R, outlen, 0 ) < 0 )
+  if( blake2sp_init_root( S->R, ( uint8_t ) outlen, 0 ) < 0 )
     return -1;
 
   for( size_t i = 0; i < PARALLELISM_DEGREE; ++i )
-    if( blake2sp_init_leaf( S->S[i], outlen, 0, i ) < 0 ) return -1;
+    if( blake2sp_init_leaf( S->S[i], ( uint8_t ) outlen, 0, i ) < 0 ) return -1;
 
   S->R->last_node = 1;
   S->S[PARALLELISM_DEGREE - 1]->last_node = 1;
-  S->outlen = outlen;
+  S->outlen = ( uint8_t ) outlen;
   return 0;
 }
 
@@ -89,15 +89,16 @@ int blake2sp_init_key( blake2sp_state *S, size_t outlen, const void *key, size_t
   memset( S->buf, 0, sizeof( S->buf ) );
   S->buflen = 0;
 
-  if( blake2sp_init_root( S->R, outlen, keylen ) < 0 )
+  if( blake2sp_init_root( S->R, ( uint8_t ) outlen, ( uint8_t ) keylen ) < 0 )
     return -1;
 
   for( size_t i = 0; i < PARALLELISM_DEGREE; ++i )
-    if( blake2sp_init_leaf( S->S[i], outlen, keylen, i ) < 0 ) return -1;
+    if( blake2sp_init_leaf( S->S[i], ( uint8_t ) outlen, ( uint8_t ) keylen, i ) < 0 )
+      return -1;
 
   S->R->last_node = 1;
   S->S[PARALLELISM_DEGREE - 1]->last_node = 1;
-  S->outlen = outlen;
+  S->outlen = ( uint8_t ) outlen;
   {
     uint8_t block[BLAKE2S_BLOCKBYTES];
     memset( block, 0, BLAKE2S_BLOCKBYTES );
@@ -137,7 +138,7 @@ int blake2sp_update( blake2sp_state *S, const uint8_t *in, size_t inlen )
 #endif
   {
 #if defined(_OPENMP)
-    size_t      id__ = omp_get_thread_num();
+    size_t      id__ = ( size_t ) omp_get_thread_num();
 #endif
     size_t inlen__ = inlen;
     const uint8_t *in__ = ( const uint8_t * )in;
@@ -157,7 +158,7 @@ int blake2sp_update( blake2sp_state *S, const uint8_t *in, size_t inlen )
   if( inlen > 0 )
     memcpy( S->buf + left, in, inlen );
 
-  S->buflen = left + inlen;
+  S->buflen = ( uint32_t ) left + ( uint32_t ) inlen;
   return 0;
 }
 
@@ -208,7 +209,8 @@ int blake2sp( uint8_t *out, const void *in, const void *key, size_t outlen, size
   if( keylen > BLAKE2S_KEYBYTES ) return -1;
 
   for( size_t i = 0; i < PARALLELISM_DEGREE; ++i )
-    if( blake2sp_init_leaf( S[i], outlen, keylen, i ) < 0 ) return -1;
+    if( blake2sp_init_leaf( S[i], ( uint8_t ) outlen, ( uint8_t ) keylen, i ) < 0 )
+      return -1;
 
   S[PARALLELISM_DEGREE - 1]->last_node = 1; // mark last node
 
@@ -233,7 +235,7 @@ int blake2sp( uint8_t *out, const void *in, const void *key, size_t outlen, size
 #endif
   {
 #if defined(_OPENMP)
-    size_t      id__ = omp_get_thread_num();
+    size_t      id__ = ( size_t ) omp_get_thread_num();
 #endif
     size_t inlen__ = inlen;
     const uint8_t *in__ = ( const uint8_t * )in;
@@ -256,7 +258,7 @@ int blake2sp( uint8_t *out, const void *in, const void *key, size_t outlen, size
     blake2s_final( S[id__], hash[id__], BLAKE2S_OUTBYTES );
   }
 
-  if( blake2sp_init_root( FS, outlen, keylen ) < 0 )
+  if( blake2sp_init_root( FS, ( uint8_t ) outlen, ( uint8_t ) keylen ) < 0 )
     return -1;
 
   FS->last_node = 1;


### PR DESCRIPTION
We use blake2b in our project and found it beneficial to enable implicit conversion warnings, which required fixing any implicit conversions in blake2b. I extended this fix to all of libb2 in case there was any interest in up-streaming this change. It might not be desirable to actually enable said warning in the project unless you have a way to test compilation in all supported environments, but the fixes could still be nice.