### PR TITLE
WIP add support for pkg-config by emmiting a libb2.pc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,3 +3,5 @@ ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = COPYING
 
 SUBDIRS = src
+
+pkgconfig_DATA = libb2.pc

--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,10 @@ AM_CONDITIONAL([USE_FAT], [test "$enable_fat" = "yes"])
 dnl Only move away from ref with SSSE3; SSE2 is generally slower
 AM_CONDITIONAL([USE_SSE], [test "$ax_cv_have_ssse3_ext" = "yes"])
 
+
+PKG_INSTALLDIR
 AC_CONFIG_FILES([Makefile
                  src/Makefile
+                 libb2.pc
                  ])
 AC_OUTPUT

--- a/libb2.pc.in
+++ b/libb2.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: Blake2
+Description: C library providing BLAKE2b, BLAKE2s, BLAKE2bp, BLAKE2sp
+URL: https://github.com/BLAKE2/libb2
+Version: @VERSION@
+Requires: 
+Cflags: -I${includedir}
+Libs: -L${libdir} -lb2


### PR DESCRIPTION
in this pr i simply bring together what i found on 

* https://lists.freedesktop.org/archives/pkg-config/2007-August/000218.html
* https://stackoverflow.com/questions/28997618/installing-pkg-config-files-to-proper-path-on-centos-with-automake
* https://autotools.io/index.html

as far i can tell it installs a pkgconfig file in the right location

i tested by `$ ./autogen.sh && ./configure --prefix=$PWD/dest && make install`

which resulted in 
```
$ tree dest/
dest/
├── include
│   └── blake2.h
└── lib
    ├── libb2.a
    ├── libb2.la
    ├── libb2.so -> libb2.so.1.0.3
    ├── libb2.so.1 -> libb2.so.1.0.3
    ├── libb2.so.1.0.3
    └── pkgconfig
        └── libb2.pc


$ cat dest/lib/pkgconfig/libb2.pc 
prefix=/home/ronny/Projects/BLAKE2/libb2/dest
exec_prefix=${prefix}
libdir=${exec_prefix}/lib
includedir=${prefix}/include

Name: Blake2
Description: C library providing BLAKE2b, BLAKE2s, BLAKE2bp, BLAKE2sp
URL: https://github.com/BLAKE2/libb2
Version: 0.98
Requires: 
Cflags: -I${includedir}
Libs: -L${libdir} -lbb2

$ PKG_CONFIG_PATH=dest/lib/pkgconfig/ pkg-config --cflags --libs libb2
-I/home/ronny/Projects/BLAKE2/libb2/dest/include -L/home/ronny/Projects/BLAKE2/libb2/dest/lib -lbb2 
```

Fixes #22 