### PR TITLE
Make secure_zero_memory() compile on HP-UX

### DIFF
--- a/src/blake2-impl.h
+++ b/src/blake2-impl.h
@@ -141,6 +141,9 @@ static inline void secure_zero_memory(void *v, size_t n)
 {
 #if defined(_WIN32) || defined(WIN32)
   SecureZeroMemory(v, n);
+#elif defined(__hpux)
+  static void *(*const volatile memset_v)(void *, int, size_t) = &memset;
+  memset_v(v, 0, n);
 #else
 // prioritize first the general C11 call
 #if defined(HAVE_MEMSET_S)


### PR DESCRIPTION
This reinstantiates the portable approach to this function dropped in
b4b241a34824b51956a7866606329a065d397525.
HP-UX does not have any of the fancy secure/explicit functions and the
compiler does not support the inline assembly syntax.

This one first showed up in Python for me: https://github.com/python/cpython/commit/51aa35e9e17eef60d04add9619fe2a7eb938358c