### PR TITLE
use -no-undefined flag with libtool

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,6 +17,7 @@ LDFLAGS += -version-info $(B2_LIBRARY_VERSION)
 
 lib_LTLIBRARIES = libb2.la
 libb2_la_LIBADD = # -lgomp -lpthread
+libb2_la_LDFLAGS = -no-undefined
 libb2_la_CPPFLAGS =  -DSUFFIX=  \
                      $(LTDLINCL) \
                      ${top_builddir}/src/


### PR DESCRIPTION
We need to tell libtool that we expect all symbols to be defined when
creating the library.  Otherwise, on platforms that do not support
undefined symbols, libtool does create the static library only.