### PR TITLE
Fix build with distcc

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,8 +19,7 @@ lib_LTLIBRARIES = libb2.la
 libb2_la_LIBADD = # -lgomp -lpthread
 libb2_la_LDFLAGS = -no-undefined
 libb2_la_CPPFLAGS =  -DSUFFIX=  \
-                     $(LTDLINCL) \
-                     ${top_builddir}/src/
+                     $(LTDLINCL)
 
 include_HEADERS = blake2.h
 


### PR DESCRIPTION
It also fixes a warning when building without distcc:

armv7a-unknown-linux-gnueabihf-gcc: warning: ../src/: linker input file unused because linking not done 

https://bugs.gentoo.org/704044