### PR TITLE
Meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,8 @@
 project('libb2', 'c', version: '0.98.1',
-  meson_version: '>=0.38.0',
+  meson_version: '>=0.47.0',
   default_options: ['optimization=3'])
+
+openmp = dependency('openmp', required: get_option('openmp'))
 
 conf = configuration_data()
 cc = meson.get_compiler('c')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('fat', type: 'boolean', value: false, description: 'build a fat binary on systems which support it')
 option('native', type: 'boolean', value: true, description: 'build a native binary with all optimizations supported')
+option('openmp', type: 'feature', value: 'auto', description: 'build with OpenMP support')

--- a/src/meson.build
+++ b/src/meson.build
@@ -25,26 +25,32 @@ if get_option('fat')
   internal_libs += [
     static_library('blake2_ref',
       'blake2b-ref.c', 'blake2s-ref.c',
+      dependencies: openmp,
       c_args: ['-DSUFFIX=_ref']
     ),
     static_library('blake2_sse2',
       'blake2b.c', 'blake2s.c',
+      dependencies: openmp,
       c_args: ['-DSUFFIX=_sse2', '-msse2']
     ),
     static_library('blake2_ssse3',
       'blake2b.c', 'blake2s.c',
+      dependencies: openmp,
       c_args: ['-DSUFFIX=_ssse3', '-msse2', '-mssse3']
     ),
     static_library('blake2_sse4.1',
       'blake2b.c', 'blake2s.c',
+      dependencies: openmp,
       c_args: ['-DSUFFIX=_sse41', '-msse2', '-mssse3', '-msse4.1']
     ),
     static_library('blake2_avx',
       'blake2b.c', 'blake2s.c',
+      dependencies: openmp,
       c_args: ['-DSUFFIX=_avx', '-msse2', '-mssse3', '-msse4.1', '-mavx']
     ),
     static_library('blake2_xop',
       'blake2b.c', 'blake2s.c',
+      dependencies: openmp,
       c_args: ['-DSUFFIX=_xop', '-msse2', '-mssse3', '-msse4.1', '-mavx', '-mxop']
     ),
   ]
@@ -64,6 +70,7 @@ install_headers('blake2.h')
 libb2 = library('b2', sources,
   c_args: '-DSUFFIX=',
   link_with: internal_libs,
+  dependencies: openmp,
   version: '1.0.4',
   install: true,
 )
@@ -72,10 +79,8 @@ libb2_dep = declare_dependency(
   link_with: libb2,
   include_directories: include_directories('.')
 )
-import('pkgconfig').generate( #libb2, # requires meson_version 0.46, not in Ubuntu 18.04
+import('pkgconfig').generate(libb2,
   name: 'libb2',
-  libraries: libb2, # implied in 0.46
-  version: meson.project_version(), # implied in 0.46
   description: 'C library providing BLAKE2b, BLAKE2s, BLAKE2bp, BLAKE2sp',
   url: 'https://github.com/BLAKE2/libb2',
 )


### PR DESCRIPTION
Fairly straightforward port from autotools to meson. Should work on Linux, *BSD, Solaris, macOS and Windows. Probably works on [AIX via gcc](https://mesonbuild.com/Release-notes-for-0-56-0.html#preliminary-aix-support).

Detecting CPU or compiler availability of instruction sets relies on GCC or clang specific `__builtin_cpu_supports` and checking if the compiler accepts `-m<iset>`, but should fall back reasonably well to unoptimized binaries on, say, MSVC -- which currently isn't supported anyway, the autotools build system is both Windows unfriendly and also hardcodes assumptions like... accepting GCC-style flags for `-m<iset>`. Oh well, at least it should build. Implementing that can be left to someone who cares about Windows.

Benefits:
- meson is really fast, compared to ./configure
- supports VS solutions on Windows (clang is recommended over MSVC due to above point, I suppose)
- supports xcode on macOS
- meson will automatically support including libb2 into your project via https://mesonbuild.com/Wrap-dependency-system-manual.html, with fine-grained control over detecting a system copy, or falling back to / forcing downloading and compiling/linking it as a private static library (see `--wrap-mode=[default|nofallback|forcefallback]` or `--force-fallback-for=libb2`)
- declarative build system is easier to reason about than turing-complete configure scripts


```
$ time meson setup builddir --prefix /usr -Dfat=true
The Meson build system
Version: 0.59.99
Source dir: /tmp/libb2
Build dir: /tmp/libb2/builddir
Build type: native build
Project name: libb2
Project version: 0.98.1
C compiler for the host machine: ccache cc (gcc 11.1.0 "cc (GCC) 11.1.0")
C linker for the host machine: cc ld.bfd 2.36.1
Host machine cpu family: x86_64
Host machine cpu: x86_64
Run-time dependency OpenMP found: YES 4.5
Compiler for C supports arguments -mavx: YES 
Compiler for C supports arguments -mavx2: YES 
Compiler for C supports arguments -msse2: YES 
Compiler for C supports arguments -mssse3: YES 
Compiler for C supports arguments -msse4.1: YES 
Compiler for C supports arguments -mxop: YES 
Configuring config.h using configuration
Build targets in project: 11

Found ninja-1.10.2 at /usr/bin/ninja
                                                                                                    
real	0m1.649s
user	0m1.428s
sys	0m0.226s
$ time ninja -C builddir
ninja: Entering directory `builddir'
[1/31] Compiling C object src/libblake2_ssse3.a.p/blake2s.c.o
../src/blake2s.c:60:22: warning: ‘blake2s_sigma’ defined but not used [-Wunused-const-variable=]
   60 | static const uint8_t blake2s_sigma[10][16] =
      |                      ^~~~~~~~~~~~~
[3/31] Compiling C object src/libblake2_sse2.a.p/blake2s.c.o
../src/blake2s.c:60:22: warning: ‘blake2s_sigma’ defined but not used [-Wunused-const-variable=]
   60 | static const uint8_t blake2s_sigma[10][16] =
      |                      ^~~~~~~~~~~~~
[6/31] Compiling C object src/libblake2_ssse3.a.p/blake2b.c.o
../src/blake2b.c:63:22: warning: ‘blake2b_sigma’ defined but not used [-Wunused-const-variable=]
   63 | static const uint8_t blake2b_sigma[12][16] =
      |                      ^~~~~~~~~~~~~
[8/31] Compiling C object src/libblake2_sse2.a.p/blake2b.c.o
../src/blake2b.c:63:22: warning: ‘blake2b_sigma’ defined but not used [-Wunused-const-variable=]
   63 | static const uint8_t blake2b_sigma[12][16] =
      |                      ^~~~~~~~~~~~~
[10/31] Compiling C object src/libblake2_sse4.1.a.p/blake2s.c.o
../src/blake2s.c:60:22: warning: ‘blake2s_sigma’ defined but not used [-Wunused-const-variable=]
   60 | static const uint8_t blake2s_sigma[10][16] =
      |                      ^~~~~~~~~~~~~
[11/31] Compiling C object src/libblake2_sse4.1.a.p/blake2b.c.o
../src/blake2b.c:63:22: warning: ‘blake2b_sigma’ defined but not used [-Wunused-const-variable=]
   63 | static const uint8_t blake2b_sigma[12][16] =
      |                      ^~~~~~~~~~~~~
[15/31] Compiling C object src/libb2.so.1.0.4.p/blake2-dispatch.c.o
../src/blake2-dispatch.c:41:19: warning: ‘feature_names’ defined but not used [-Wunused-const-variable=]
   41 | static const char feature_names[][8] =
      |                   ^~~~~~~~~~~~~
[16/31] Compiling C object src/libblake2_avx.a.p/blake2s.c.o
../src/blake2s.c:60:22: warning: ‘blake2s_sigma’ defined but not used [-Wunused-const-variable=]
   60 | static const uint8_t blake2s_sigma[10][16] =
      |                      ^~~~~~~~~~~~~
[18/31] Compiling C object src/libblake2_avx.a.p/blake2b.c.o
../src/blake2b.c:63:22: warning: ‘blake2b_sigma’ defined but not used [-Wunused-const-variable=]
   63 | static const uint8_t blake2b_sigma[12][16] =
      |                      ^~~~~~~~~~~~~
[20/31] Compiling C object src/libblake2_xop.a.p/blake2s.c.o
../src/blake2s.c:60:22: warning: ‘blake2s_sigma’ defined but not used [-Wunused-const-variable=]
   60 | static const uint8_t blake2s_sigma[10][16] =
      |                      ^~~~~~~~~~~~~
[22/31] Compiling C object src/libblake2_xop.a.p/blake2b.c.o
../src/blake2b.c:63:22: warning: ‘blake2b_sigma’ defined but not used [-Wunused-const-variable=]
   63 | static const uint8_t blake2b_sigma[12][16] =
      |                      ^~~~~~~~~~~~~
[31/31] Linking target src/blake2sp-test

real	0m5.326s
user	0m15.603s
sys	0m1.219s
$ ninja -C builddir test
ninja: Entering directory `builddir'
[0/1] Running all tests.
1/4 blake2s-test         OK              0.02s
2/4 blake2b-test         OK              0.01s
3/4 blake2sp-test        OK              0.02s
4/4 blake2bp-test        OK              0.03s


Ok:                 4   
Expected Fail:      0   
Fail:               0   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0   

Full log written to /tmp/libb2/builddir/meson-logs/testlog.txt
```

This is a third of the time ./configure or make takes on the same machine. :)

Note that libb2 currently fails to ./configure properly at all, unless you run it as `bash configure --prefix /usr --enable-fat` it trips over a syntax error and disables both fat and native binaries.