### PR TITLE
Fix build with Clang

### DIFF
--- a/src/blake2b.c
+++ b/src/blake2b.c
@@ -27,7 +27,7 @@
 #if defined(HAVE_SSE2)
 #include <emmintrin.h>
 // MSVC only defines  _mm_set_epi64x for x86_64...
-#if defined(_MSC_VER) && !defined(_M_X64)
+#if defined(_MSC_VER) && !defined(_M_X64) && !defined(__clang__)
 static inline __m128i _mm_set_epi64x( const uint64_t u1, const uint64_t u0 )
 {
   return _mm_set_epi32( u1 >> 32, u1, u0 >> 32, u0 );

--- a/src/blake2s.c
+++ b/src/blake2s.c
@@ -27,7 +27,7 @@
 #if defined(HAVE_SSE2)
 #include <emmintrin.h>
 // MSVC only defines  _mm_set_epi64x for x86_64...
-#if defined(_MSC_VER) && !defined(_M_X64)
+#if defined(_MSC_VER) && !defined(_M_X64) && !defined(__clang__)
 static inline __m128i _mm_set_epi64x( const uint64_t u1, const uint64_t u0 )
 {
   return _mm_set_epi32( u1 >> 32, u1, u0 >> 32, u0 );


### PR DESCRIPTION
Output with error:
```
In file included from $(SOURCE_ROOT)/python3/src/Modules/_blake2/blake2b_impl.c:30:
$(SOURCE_ROOT)/python3/src/Modules/_blake2/impl/blake2b.c(31,23): error: conflicting types for '_mm_set_epi64x'
static inline __m128i _mm_set_epi64x( const uint64_t u1, const uint64_t u0 )
                      ^
$(TOOL_ROOT)/clang/14.0.6/include/emmintrin.h(3613,1): note: previous definition is here
_mm_set_epi64x(long long __q1, long long __q0)
^
1 error generated.
```